### PR TITLE
Add complete runnable Python 3D incompressible LES solver project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,59 @@
+# CFDLES: 3D Incompressible LES Solver (Python)
+
+Educational, runnable 3D incompressible Navier–Stokes LES solver with:
+- Fractional-step / projection method
+- Smagorinsky–Lilly SGS (+ Van Driest wall damping option)
+- Structured finite-volume-like mesh with nonuniform spacing and auto-mesh refinement weights
+- Periodic/wall/inflow/outflow boundary conditions
+- Pressure Poisson CG / BiCGSTAB with Jacobi preconditioning
+- VTK output for ParaView
+- Built-in demos and operator tests
+
+## Install
+
+```bash
+python -m venv .venv && source .venv/bin/activate && pip install -e .
+```
+
+## One-command default demo run
+
+```bash
+python run_demo.py demos/cavity.json
+```
+
+This writes VTK + CSV logs to `outputs/cavity/`.
+
+## Other demos
+
+```bash
+python run_demo.py demos/channel.json
+python run_demo.py demos/sphere.json
+```
+
+## Plot diagnostics
+
+```bash
+python plot_results.py demos/cavity.json
+```
+
+## What gets saved
+- `*.vtk` fields: `u, v, w, p, nu_t, S_mag, divergence`
+- `*_log.csv`: step, time, dt, CFL, pressure residual, kinetic energy, divergence norm, mean `nu_t`
+
+## Expected qualitative demo behavior
+- **Cavity:** top moving lid drives a primary recirculation + 3D corner vortices.
+- **Channel:** periodic streamwise/spanwise flow with near-wall shear and turbulent-like fluctuations.
+- **Sphere:** wake-like low-speed region behind immersed sphere (Brinkman penalization).
+
+## Tests
+
+```bash
+pytest -q
+```
+
+## Notes / limitations
+- Spatial operators are cell-centered and prioritize clarity over high-order accuracy.
+- Diffusion is explicit; dt includes both CFL and diffusion limits.
+- Pressure operator is matrix-free and robust for small-medium grids; for large cases, a multigrid preconditioner is recommended.
+- SGS extension point: add new model in `cfdles/sgs.py` and switch in `timestepper.py`.
+- Implicit diffusion could be added by solving Helmholtz systems for each velocity component.

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ Educational, runnable 3D incompressible Navier–Stokes LES solver with:
 - Structured finite-volume-like mesh with nonuniform spacing and auto-mesh refinement weights
 - Periodic/wall/inflow/outflow boundary conditions
 - Pressure Poisson CG / BiCGSTAB with Jacobi preconditioning
-- VTK output for ParaView
-- Built-in demos and operator tests
+- VTK + NPZ outputs for ParaView and native GUI
+- Built-in demos, diagnostics plots, and operator tests
+- **Desktop GUI** for interactive visualization and run control
 
 ## Install
 
@@ -21,7 +22,20 @@ python -m venv .venv && source .venv/bin/activate && pip install -e .
 python run_demo.py demos/cavity.json
 ```
 
-This writes VTK + CSV logs to `outputs/cavity/`.
+This writes VTK/NPZ + CSV logs to `outputs/cavity/`.
+
+## Launch GUI (recommended)
+
+```bash
+python run_gui.py
+```
+
+In the GUI you can:
+- run a demo from its config JSON,
+- browse generated `.npz` snapshots,
+- view scalar slices (`u,v,w,p,nu_t,s_mag,divergence`),
+- overlay in-plane velocity vectors,
+- monitor kinetic energy and divergence trends.
 
 ## Other demos
 
@@ -30,7 +44,7 @@ python run_demo.py demos/channel.json
 python run_demo.py demos/sphere.json
 ```
 
-## Plot diagnostics
+## Plot diagnostics (script)
 
 ```bash
 python plot_results.py demos/cavity.json
@@ -38,6 +52,7 @@ python plot_results.py demos/cavity.json
 
 ## What gets saved
 - `*.vtk` fields: `u, v, w, p, nu_t, S_mag, divergence`
+- `*.npz` snapshot bundles: mesh + fields for quick GUI loading
 - `*_log.csv`: step, time, dt, CFL, pressure residual, kinetic energy, divergence norm, mean `nu_t`
 
 ## Expected qualitative demo behavior

--- a/cfdles/__init__.py
+++ b/cfdles/__init__.py
@@ -1,0 +1,6 @@
+"""cfdles package."""
+
+from .config import SolverConfig, load_config
+from .timestepper import run_simulation
+
+__all__ = ["SolverConfig", "load_config", "run_simulation"]

--- a/cfdles/bc.py
+++ b/cfdles/bc.py
@@ -1,0 +1,99 @@
+"""Boundary-condition application for velocity and pressure."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .config import SolverConfig
+
+
+def _periodic_copy(phi: np.ndarray, axis: int) -> None:
+    if axis == 0:
+        phi[0, :, :] = phi[-2, :, :]
+        phi[-1, :, :] = phi[1, :, :]
+    elif axis == 1:
+        phi[:, 0, :] = phi[:, -2, :]
+        phi[:, -1, :] = phi[:, 1, :]
+    else:
+        phi[:, :, 0] = phi[:, :, -2]
+        phi[:, :, -1] = phi[:, :, 1]
+
+
+def apply_velocity_bcs(u: np.ndarray, v: np.ndarray, w: np.ndarray, cfg: SolverConfig) -> None:
+    """Apply boundary conditions on ghost cells."""
+    bc = cfg.bcs
+    periodic = bc.get("periodic", [])
+    if "x" in periodic:
+        _periodic_copy(u, 0)
+        _periodic_copy(v, 0)
+        _periodic_copy(w, 0)
+    else:
+        u[0, :, :] = -u[1, :, :]
+        u[-1, :, :] = -u[-2, :, :]
+        v[0, :, :] = -v[1, :, :]
+        v[-1, :, :] = -v[-2, :, :]
+        w[0, :, :] = -w[1, :, :]
+        w[-1, :, :] = -w[-2, :, :]
+
+    if "y" in periodic:
+        _periodic_copy(u, 1)
+        _periodic_copy(v, 1)
+        _periodic_copy(w, 1)
+    else:
+        u[:, 0, :] = -u[:, 1, :]
+        v[:, 0, :] = -v[:, 1, :]
+        w[:, 0, :] = -w[:, 1, :]
+        top_u = float(bc.get("moving_wall", {}).get("u", 0.0))
+        u[:, -1, :] = 2.0 * top_u - u[:, -2, :]
+        v[:, -1, :] = -v[:, -2, :]
+        w[:, -1, :] = -w[:, -2, :]
+
+    if "z" in periodic:
+        _periodic_copy(u, 2)
+        _periodic_copy(v, 2)
+        _periodic_copy(w, 2)
+    else:
+        inflow = bc.get("inflow", {})
+        if inflow.get("at") == "zmin":
+            val = inflow.get("velocity", [1.0, 0.0, 0.0])
+            u[:, :, 0] = 2.0 * val[0] - u[:, :, 1]
+            v[:, :, 0] = 2.0 * val[1] - v[:, :, 1]
+            w[:, :, 0] = 2.0 * val[2] - w[:, :, 1]
+        else:
+            u[:, :, 0] = -u[:, :, 1]
+            v[:, :, 0] = -v[:, :, 1]
+            w[:, :, 0] = -w[:, :, 1]
+
+        if bc.get("outflow", {}).get("at") == "zmax":
+            u[:, :, -1] = u[:, :, -2]
+            v[:, :, -1] = v[:, :, -2]
+            w[:, :, -1] = w[:, :, -2]
+        else:
+            u[:, :, -1] = -u[:, :, -2]
+            v[:, :, -1] = -v[:, :, -2]
+            w[:, :, -1] = -w[:, :, -2]
+
+
+def apply_pressure_bcs(p: np.ndarray, cfg: SolverConfig) -> None:
+    bc = cfg.bcs
+    periodic = bc.get("periodic", [])
+    if "x" in periodic:
+        _periodic_copy(p, 0)
+    else:
+        p[0, :, :] = p[1, :, :]
+        p[-1, :, :] = p[-2, :, :]
+
+    if "y" in periodic:
+        _periodic_copy(p, 1)
+    else:
+        p[:, 0, :] = p[:, 1, :]
+        p[:, -1, :] = p[:, -2, :]
+
+    if "z" in periodic:
+        _periodic_copy(p, 2)
+    else:
+        p[:, :, 0] = p[:, :, 1]
+        p[:, :, -1] = p[:, :, -2]
+
+    ref = cfg.pressure_reference
+    p[ref] = 0.0

--- a/cfdles/config.py
+++ b/cfdles/config.py
@@ -1,0 +1,127 @@
+"""Configuration loading and validation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class LESConfig:
+    cs: float = 0.17
+    wall_damping: bool = False
+    van_driest_a_plus: float = 26.0
+
+
+@dataclass
+class TimeConfig:
+    cfl_target: float = 0.5
+    dt: float | None = None
+    t_end: float = 2.0
+    max_steps: int = 2000
+
+
+@dataclass
+class OutputConfig:
+    interval: int = 20
+    directory: str = "outputs"
+    prefix: str = "sol"
+
+
+@dataclass
+class MeshConfig:
+    nx: int = 32
+    ny: int = 32
+    nz: int = 32
+    lengths: tuple[float, float, float] = (1.0, 1.0, 1.0)
+    near_wall_stretching: dict[str, Any] = field(default_factory=dict)
+    refinement_zones: list[dict[str, Any]] = field(default_factory=list)
+
+
+@dataclass
+class SolverConfig:
+    domain: str = "cavity"
+    rho: float = 1.0
+    nu: float = 0.01
+    body_force: tuple[float, float, float] = (0.0, 0.0, 0.0)
+    mesh: MeshConfig = field(default_factory=MeshConfig)
+    time: TimeConfig = field(default_factory=TimeConfig)
+    les: LESConfig = field(default_factory=LESConfig)
+    output: OutputConfig = field(default_factory=OutputConfig)
+    convection_scheme: str = "central"
+    central_blend: float = 0.1
+    pressure_tol: float = 1e-6
+    pressure_max_iter: int = 400
+    pressure_solver: str = "cg"
+    pressure_reference: tuple[int, int, int] = (1, 1, 1)
+    bcs: dict[str, Any] = field(default_factory=dict)
+    sphere: dict[str, Any] = field(default_factory=dict)
+
+
+def _tuple3(values: Any, key: str) -> tuple[float, float, float]:
+    if not isinstance(values, (list, tuple)) or len(values) != 3:
+        raise ValueError(f"{key} must be a list/tuple of length 3")
+    return (float(values[0]), float(values[1]), float(values[2]))
+
+
+def load_config(path: str | Path) -> SolverConfig:
+    """Load JSON config into SolverConfig with friendly errors."""
+    raw = json.loads(Path(path).read_text())
+    cfg = SolverConfig()
+    cfg.domain = str(raw.get("domain", cfg.domain)).lower()
+    cfg.rho = float(raw.get("rho", cfg.rho))
+    cfg.nu = float(raw.get("nu", cfg.nu))
+    cfg.body_force = _tuple3(raw.get("body_force", cfg.body_force), "body_force")
+
+    mesh_raw = raw.get("mesh", {})
+    cfg.mesh = MeshConfig(
+        nx=int(mesh_raw.get("nx", cfg.mesh.nx)),
+        ny=int(mesh_raw.get("ny", cfg.mesh.ny)),
+        nz=int(mesh_raw.get("nz", cfg.mesh.nz)),
+        lengths=_tuple3(mesh_raw.get("lengths", cfg.mesh.lengths), "mesh.lengths"),
+        near_wall_stretching=mesh_raw.get("near_wall_stretching", {}),
+        refinement_zones=mesh_raw.get("refinement_zones", []),
+    )
+
+    time_raw = raw.get("time", {})
+    cfg.time = TimeConfig(
+        cfl_target=float(time_raw.get("cfl_target", cfg.time.cfl_target)),
+        dt=time_raw.get("dt", cfg.time.dt),
+        t_end=float(time_raw.get("t_end", cfg.time.t_end)),
+        max_steps=int(time_raw.get("max_steps", cfg.time.max_steps)),
+    )
+    if cfg.time.dt is not None:
+        cfg.time.dt = float(cfg.time.dt)
+
+    les_raw = raw.get("les", {})
+    cfg.les = LESConfig(
+        cs=float(les_raw.get("cs", cfg.les.cs)),
+        wall_damping=bool(les_raw.get("wall_damping", cfg.les.wall_damping)),
+        van_driest_a_plus=float(les_raw.get("van_driest_a_plus", cfg.les.van_driest_a_plus)),
+    )
+
+    out_raw = raw.get("output", {})
+    cfg.output = OutputConfig(
+        interval=int(out_raw.get("interval", cfg.output.interval)),
+        directory=str(out_raw.get("directory", cfg.output.directory)),
+        prefix=str(out_raw.get("prefix", cfg.output.prefix)),
+    )
+
+    cfg.convection_scheme = str(raw.get("convection_scheme", cfg.convection_scheme)).lower()
+    cfg.central_blend = float(raw.get("central_blend", cfg.central_blend))
+    cfg.pressure_tol = float(raw.get("pressure_tol", cfg.pressure_tol))
+    cfg.pressure_max_iter = int(raw.get("pressure_max_iter", cfg.pressure_max_iter))
+    cfg.pressure_solver = str(raw.get("pressure_solver", cfg.pressure_solver)).lower()
+    cfg.pressure_reference = tuple(raw.get("pressure_reference", cfg.pressure_reference))
+    cfg.bcs = raw.get("bcs", {})
+    cfg.sphere = raw.get("sphere", {})
+
+    if cfg.mesh.nx < 4 or cfg.mesh.ny < 4 or cfg.mesh.nz < 4:
+        raise ValueError("nx, ny, nz must each be >= 4")
+    if cfg.nu <= 0.0:
+        raise ValueError("nu must be > 0")
+    if cfg.time.cfl_target <= 0.0:
+        raise ValueError("time.cfl_target must be > 0")
+    return cfg

--- a/cfdles/diagnostics.py
+++ b/cfdles/diagnostics.py
@@ -1,0 +1,51 @@
+"""Diagnostics and lightweight logging."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import numpy as np
+
+from .mesh import StructuredMesh
+from .operators import divergence, vorticity_magnitude
+
+
+@dataclass
+class StepDiagnostics:
+    kinetic_energy: float
+    div_l2: float
+    nu_t_mean: float
+    cfl: float
+    pressure_residual: float
+
+
+def compute_diagnostics(
+    u: np.ndarray,
+    v: np.ndarray,
+    w: np.ndarray,
+    nu_t: np.ndarray,
+    mesh: StructuredMesh,
+    dt: float,
+    pressure_residual: float,
+) -> StepDiagnostics:
+    ui, vi, wi = u[1:-1, 1:-1, 1:-1], v[1:-1, 1:-1, 1:-1], w[1:-1, 1:-1, 1:-1]
+    ke = 0.5 * np.sum((ui**2 + vi**2 + wi**2) * mesh.vol) / np.sum(mesh.vol)
+    div = divergence(u, v, w, mesh)[1:-1, 1:-1, 1:-1]
+    div_l2 = float(np.sqrt(np.mean(div**2)))
+    speed = np.sqrt(ui**2 + vi**2 + wi**2)
+    min_h = min(np.min(mesh.dx), np.min(mesh.dy), np.min(mesh.dz))
+    cfl = float(np.max(speed) * dt / max(min_h, 1e-12))
+    return StepDiagnostics(float(ke), div_l2, float(np.mean(nu_t)), cfl, pressure_residual)
+
+
+def append_log(path: Path, step: int, time: float, dt: float, d: StepDiagnostics) -> None:
+    if not path.exists():
+        path.write_text("step,time,dt,cfl,pressure_residual,kinetic_energy,div_l2,nu_t_mean\n")
+    with path.open("a", encoding="utf-8") as f:
+        f.write(f"{step},{time:.8e},{dt:.8e},{d.cfl:.5f},{d.pressure_residual:.5e},{d.kinetic_energy:.8e},{d.div_l2:.8e},{d.nu_t_mean:.8e}\n")
+
+
+def vorticity_slice(u: np.ndarray, v: np.ndarray, w: np.ndarray, mesh: StructuredMesh, k: int | None = None) -> np.ndarray:
+    om = vorticity_magnitude(u, v, w, mesh)[1:-1, 1:-1, 1:-1]
+    kk = om.shape[2] // 2 if k is None else k
+    return om[:, :, kk]

--- a/cfdles/gui.py
+++ b/cfdles/gui.py
@@ -1,0 +1,192 @@
+"""Desktop GUI for running demos and visualizing LES outputs."""
+
+from __future__ import annotations
+
+import subprocess
+import threading
+from pathlib import Path
+import tkinter as tk
+from tkinter import ttk, messagebox
+
+import numpy as np
+from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
+from matplotlib.figure import Figure
+
+
+class CFDLESGUI(tk.Tk):
+    """Simple Tk GUI for launching runs and visualizing snapshots."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.title("CFDLES GUI")
+        self.geometry("1180x760")
+
+        self.config_var = tk.StringVar(value="demos/cavity.json")
+        self.output_var = tk.StringVar(value="outputs/cavity")
+        self.status_var = tk.StringVar(value="Ready")
+        self.slice_axis_var = tk.StringVar(value="z")
+        self.slice_index_var = tk.IntVar(value=0)
+        self.field_var = tk.StringVar(value="u")
+
+        self.snapshot_files: list[Path] = []
+        self.current_snapshot: dict[str, np.ndarray] | None = None
+
+        self._build_layout()
+
+    def _build_layout(self) -> None:
+        controls = ttk.Frame(self)
+        controls.pack(fill=tk.X, padx=8, pady=8)
+
+        ttk.Label(controls, text="Config JSON").grid(row=0, column=0, sticky="w")
+        ttk.Entry(controls, textvariable=self.config_var, width=35).grid(row=0, column=1, sticky="we", padx=6)
+        ttk.Button(controls, text="Run Simulation", command=self.run_case).grid(row=0, column=2, padx=4)
+
+        ttk.Label(controls, text="Output Folder").grid(row=1, column=0, sticky="w")
+        ttk.Entry(controls, textvariable=self.output_var, width=35).grid(row=1, column=1, sticky="we", padx=6)
+        ttk.Button(controls, text="Refresh Files", command=self.refresh_files).grid(row=1, column=2, padx=4)
+
+        ttk.Label(controls, text="Field").grid(row=0, column=3, sticky="w", padx=(24, 0))
+        field_cb = ttk.Combobox(controls, textvariable=self.field_var, values=["u", "v", "w", "p", "nu_t", "s_mag", "divergence"], width=11)
+        field_cb.grid(row=0, column=4, padx=4)
+        field_cb.bind("<<ComboboxSelected>>", lambda _e: self.plot_snapshot())
+
+        ttk.Label(controls, text="Slice axis").grid(row=1, column=3, sticky="w", padx=(24, 0))
+        axis_cb = ttk.Combobox(controls, textvariable=self.slice_axis_var, values=["x", "y", "z"], width=11)
+        axis_cb.grid(row=1, column=4, padx=4)
+        axis_cb.bind("<<ComboboxSelected>>", lambda _e: self.plot_snapshot())
+
+        ttk.Label(controls, text="Slice index").grid(row=0, column=5, sticky="w")
+        idx_spin = ttk.Spinbox(controls, from_=0, to=999, textvariable=self.slice_index_var, width=8, command=self.plot_snapshot)
+        idx_spin.grid(row=0, column=6, padx=4)
+
+        ttk.Label(controls, textvariable=self.status_var).grid(row=1, column=5, columnspan=2, sticky="w")
+        controls.columnconfigure(1, weight=1)
+
+        main = ttk.Panedwindow(self, orient=tk.HORIZONTAL)
+        main.pack(fill=tk.BOTH, expand=True, padx=8, pady=(0, 8))
+
+        left = ttk.Frame(main)
+        right = ttk.Frame(main)
+        main.add(left, weight=1)
+        main.add(right, weight=3)
+
+        ttk.Label(left, text="Snapshots (.npz)").pack(anchor="w")
+        self.file_list = tk.Listbox(left)
+        self.file_list.pack(fill=tk.BOTH, expand=True, pady=6)
+        self.file_list.bind("<<ListboxSelect>>", self.on_select_snapshot)
+
+        self.fig = Figure(figsize=(8, 6), dpi=100)
+        self.ax_field = self.fig.add_subplot(2, 2, 1)
+        self.ax_quiver = self.fig.add_subplot(2, 2, 2)
+        self.ax_ke = self.fig.add_subplot(2, 1, 2)
+        self.canvas = FigureCanvasTkAgg(self.fig, master=right)
+        self.canvas.get_tk_widget().pack(fill=tk.BOTH, expand=True)
+
+    def run_case(self) -> None:
+        cfg = Path(self.config_var.get())
+        if not cfg.exists():
+            messagebox.showerror("Missing config", f"Config not found: {cfg}")
+            return
+
+        def worker() -> None:
+            self.status_var.set("Running simulation...")
+            try:
+                subprocess.run(["python", "run_demo.py", str(cfg)], check=True)
+                self.status_var.set("Simulation complete")
+                self.refresh_files()
+            except subprocess.CalledProcessError as exc:
+                self.status_var.set("Run failed")
+                messagebox.showerror("Run failed", str(exc))
+
+        threading.Thread(target=worker, daemon=True).start()
+
+    def refresh_files(self) -> None:
+        out = Path(self.output_var.get())
+        out.mkdir(parents=True, exist_ok=True)
+        self.snapshot_files = sorted(out.glob("*.npz"))
+        self.file_list.delete(0, tk.END)
+        for p in self.snapshot_files:
+            self.file_list.insert(tk.END, p.name)
+        if self.snapshot_files:
+            self.file_list.selection_clear(0, tk.END)
+            self.file_list.selection_set(tk.END)
+            self.file_list.event_generate("<<ListboxSelect>>")
+
+    def on_select_snapshot(self, _event: object) -> None:
+        selection = self.file_list.curselection()
+        if not selection:
+            return
+        snap = self.snapshot_files[selection[0]]
+        with np.load(snap) as data:
+            self.current_snapshot = {k: data[k] for k in data.files}
+        self.status_var.set(f"Loaded {snap.name}")
+        self.plot_snapshot()
+
+    def _slice_field(self, arr: np.ndarray, axis: str, idx: int) -> np.ndarray:
+        if axis == "x":
+            idx = max(0, min(idx, arr.shape[0] - 1))
+            return arr[idx, :, :]
+        if axis == "y":
+            idx = max(0, min(idx, arr.shape[1] - 1))
+            return arr[:, idx, :]
+        idx = max(0, min(idx, arr.shape[2] - 1))
+        return arr[:, :, idx]
+
+    def plot_snapshot(self) -> None:
+        if self.current_snapshot is None:
+            return
+
+        field_name = self.field_var.get()
+        axis = self.slice_axis_var.get()
+        idx = int(self.slice_index_var.get())
+
+        arr = self.current_snapshot[field_name]
+        fld = self._slice_field(arr, axis, idx)
+
+        self.ax_field.clear()
+        im = self.ax_field.imshow(fld.T, origin="lower", aspect="auto", cmap="turbo")
+        self.ax_field.set_title(f"{field_name} slice ({axis}={idx})")
+        self.fig.colorbar(im, ax=self.ax_field, fraction=0.046, pad=0.04)
+
+        u = self.current_snapshot["u"]
+        v = self.current_snapshot["v"]
+        w = self.current_snapshot["w"]
+        self.ax_quiver.clear()
+        if axis == "x":
+            uu = self._slice_field(v, axis, idx)
+            vv = self._slice_field(w, axis, idx)
+        elif axis == "y":
+            uu = self._slice_field(u, axis, idx)
+            vv = self._slice_field(w, axis, idx)
+        else:
+            uu = self._slice_field(u, axis, idx)
+            vv = self._slice_field(v, axis, idx)
+
+        stride = max(1, min(uu.shape[0], uu.shape[1]) // 24)
+        yy, xx = np.mgrid[0:uu.shape[0]:stride, 0:uu.shape[1]:stride]
+        self.ax_quiver.quiver(xx, yy, uu[::stride, ::stride].T, vv[::stride, ::stride].T, scale=20)
+        self.ax_quiver.set_title("In-plane velocity vectors")
+
+        self.ax_ke.clear()
+        out_dir = Path(self.output_var.get())
+        csv_files = sorted(out_dir.glob("*_log.csv"))
+        if csv_files:
+            data = np.genfromtxt(csv_files[-1], delimiter=",", names=True)
+            if data.size > 0:
+                self.ax_ke.plot(data["time"], data["kinetic_energy"], label="KE")
+                self.ax_ke.plot(data["time"], data["div_l2"], label="||div||")
+                self.ax_ke.set_xlabel("time")
+                self.ax_ke.legend()
+                self.ax_ke.set_title("Run diagnostics")
+
+        self.fig.tight_layout()
+        self.canvas.draw_idle()
+
+
+def main() -> None:
+    app = CFDLESGUI()
+    app.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/cfdles/io_npz.py
+++ b/cfdles/io_npz.py
@@ -1,0 +1,42 @@
+"""Compact NumPy snapshot output for fast post-processing/GUI."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import numpy as np
+
+from .mesh import StructuredMesh
+
+
+def write_snapshot_npz(
+    path: str | Path,
+    mesh: StructuredMesh,
+    u: np.ndarray,
+    v: np.ndarray,
+    w: np.ndarray,
+    p: np.ndarray,
+    nu_t: np.ndarray,
+    s_mag: np.ndarray,
+    divergence: np.ndarray,
+    time: float,
+    step: int,
+) -> None:
+    """Write a compressed snapshot with mesh and fields for GUI/postprocessing."""
+    np.savez_compressed(
+        Path(path),
+        x_edges=mesh.x_edges,
+        y_edges=mesh.y_edges,
+        z_edges=mesh.z_edges,
+        xc=mesh.xc,
+        yc=mesh.yc,
+        zc=mesh.zc,
+        u=u,
+        v=v,
+        w=w,
+        p=p,
+        nu_t=nu_t,
+        s_mag=s_mag,
+        divergence=divergence,
+        time=float(time),
+        step=int(step),
+    )

--- a/cfdles/io_vtk.py
+++ b/cfdles/io_vtk.py
@@ -1,0 +1,37 @@
+"""VTK output helpers (legacy rectilinear grid)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import numpy as np
+
+from .mesh import StructuredMesh
+
+
+def _flatten_cell(a: np.ndarray) -> np.ndarray:
+    return np.asarray(a, dtype=float).transpose(2, 1, 0).ravel()
+
+
+def write_vtk_rectilinear(path: str | Path, mesh: StructuredMesh, fields: dict[str, np.ndarray]) -> None:
+    path = Path(path)
+    nx, ny, nz = mesh.nx, mesh.ny, mesh.nz
+    with path.open("w", encoding="utf-8") as f:
+        f.write("# vtk DataFile Version 3.0\n")
+        f.write("cfdles output\n")
+        f.write("ASCII\n")
+        f.write("DATASET RECTILINEAR_GRID\n")
+        f.write(f"DIMENSIONS {nx+1} {ny+1} {nz+1}\n")
+        f.write(f"X_COORDINATES {nx+1} float\n")
+        f.write(" ".join(f"{x:.8e}" for x in mesh.x_edges) + "\n")
+        f.write(f"Y_COORDINATES {ny+1} float\n")
+        f.write(" ".join(f"{y:.8e}" for y in mesh.y_edges) + "\n")
+        f.write(f"Z_COORDINATES {nz+1} float\n")
+        f.write(" ".join(f"{z:.8e}" for z in mesh.z_edges) + "\n")
+        f.write(f"CELL_DATA {nx*ny*nz}\n")
+
+        for name, arr in fields.items():
+            data = _flatten_cell(arr)
+            f.write(f"SCALARS {name} float 1\n")
+            f.write("LOOKUP_TABLE default\n")
+            for i in range(0, data.size, 8):
+                f.write(" ".join(f"{v:.8e}" for v in data[i : i + 8]) + "\n")

--- a/cfdles/mesh.py
+++ b/cfdles/mesh.py
@@ -1,0 +1,98 @@
+"""Automatic structured hexahedral mesh generation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import numpy as np
+
+from .config import SolverConfig
+
+
+@dataclass
+class StructuredMesh:
+    nx: int
+    ny: int
+    nz: int
+    x_edges: np.ndarray
+    y_edges: np.ndarray
+    z_edges: np.ndarray
+    xc: np.ndarray
+    yc: np.ndarray
+    zc: np.ndarray
+    dx: np.ndarray
+    dy: np.ndarray
+    dz: np.ndarray
+    vol: np.ndarray
+    delta: np.ndarray
+    mask_solid: np.ndarray
+
+
+def _build_axis_edges(n: int, length: float, stretching: dict, axis: str, zones: list[dict]) -> np.ndarray:
+    weights = np.ones(n, dtype=float)
+    for zone in zones:
+        zmin, zmax = zone["min"], zone["max"]
+        factor = float(zone.get("factor", 2.0))
+        amin = float(zmin[{"x": 0, "y": 1, "z": 2}[axis]])
+        amax = float(zmax[{"x": 0, "y": 1, "z": 2}[axis]])
+        left = int(np.clip(np.floor(amin / length * n), 0, n - 1))
+        right = int(np.clip(np.ceil(amax / length * n), 1, n))
+        weights[left:right] /= factor
+
+    if stretching.get("axis") == axis:
+        kind = stretching.get("type", "tanh")
+        strength = float(stretching.get("strength", 1.8))
+        s = (np.arange(n) + 0.5) / n
+        if kind == "tanh":
+            prof = 1.0 - 0.6 * np.tanh(strength * (2.0 * np.abs(s - 0.5)))
+        else:
+            prof = np.exp(-strength * np.abs(s - 0.5))
+        weights *= np.clip(prof, 0.08, None)
+
+    widths = weights / np.sum(weights) * length
+    edges = np.zeros(n + 1)
+    edges[1:] = np.cumsum(widths)
+    return edges
+
+
+def _sphere_mask(cfg: SolverConfig, xc: np.ndarray, yc: np.ndarray, zc: np.ndarray) -> np.ndarray:
+    if cfg.domain != "sphere":
+        return np.zeros((cfg.mesh.nx, cfg.mesh.ny, cfg.mesh.nz), dtype=float)
+    center = cfg.sphere.get("center", [0.4 * cfg.mesh.lengths[0], 0.5 * cfg.mesh.lengths[1], 0.5 * cfg.mesh.lengths[2]])
+    radius = float(cfg.sphere.get("radius", 0.1 * min(cfg.mesh.lengths)))
+    X, Y, Z = np.meshgrid(xc, yc, zc, indexing="ij")
+    r2 = (X - center[0]) ** 2 + (Y - center[1]) ** 2 + (Z - center[2]) ** 2
+    return (r2 <= radius**2).astype(float)
+
+
+def generate_mesh(cfg: SolverConfig) -> StructuredMesh:
+    """Generate a nonuniform structured mesh and solid indicator mask."""
+    nx, ny, nz = cfg.mesh.nx, cfg.mesh.ny, cfg.mesh.nz
+    lx, ly, lz = cfg.mesh.lengths
+    zones = cfg.mesh.refinement_zones
+    stretch = cfg.mesh.near_wall_stretching
+
+    x_edges = _build_axis_edges(nx, lx, stretch, "x", zones)
+    y_edges = _build_axis_edges(ny, ly, stretch, "y", zones)
+    z_edges = _build_axis_edges(nz, lz, stretch, "z", zones)
+
+    xc = 0.5 * (x_edges[:-1] + x_edges[1:])
+    yc = 0.5 * (y_edges[:-1] + y_edges[1:])
+    zc = 0.5 * (z_edges[:-1] + z_edges[1:])
+    dx = np.diff(x_edges)
+    dy = np.diff(y_edges)
+    dz = np.diff(z_edges)
+
+    vol = dx[:, None, None] * dy[None, :, None] * dz[None, None, :]
+    delta = np.cbrt(vol)
+    mask_solid = _sphere_mask(cfg, xc, yc, zc)
+
+    return StructuredMesh(nx, ny, nz, x_edges, y_edges, z_edges, xc, yc, zc, dx, dy, dz, vol, delta, mask_solid)
+
+
+def mesh_density_slice(mesh: StructuredMesh, axis: str = "y") -> tuple[np.ndarray, np.ndarray]:
+    """Return slice coordinates and reciprocal spacing for quick plotting."""
+    if axis == "x":
+        return mesh.xc, 1.0 / mesh.dx
+    if axis == "z":
+        return mesh.zc, 1.0 / mesh.dz
+    return mesh.yc, 1.0 / mesh.dy

--- a/cfdles/operators.py
+++ b/cfdles/operators.py
@@ -1,0 +1,84 @@
+"""Discrete differential operators on ghosted cell-centered arrays."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .mesh import StructuredMesh
+
+
+Interior = tuple[slice, slice, slice]
+
+
+def interior_slices() -> Interior:
+    return (slice(1, -1), slice(1, -1), slice(1, -1))
+
+
+def _cell_centers_from_widths(d: np.ndarray) -> np.ndarray:
+    return np.cumsum(d) - 0.5 * d
+
+
+def d_dx(phi: np.ndarray, dx: np.ndarray) -> np.ndarray:
+    out = np.zeros_like(phi)
+    x = _cell_centers_from_widths(dx)
+    out[1:-1, 1:-1, 1:-1] = np.gradient(phi[1:-1, 1:-1, 1:-1], x, axis=0, edge_order=2)
+    return out
+
+
+def d_dy(phi: np.ndarray, dy: np.ndarray) -> np.ndarray:
+    out = np.zeros_like(phi)
+    y = _cell_centers_from_widths(dy)
+    out[1:-1, 1:-1, 1:-1] = np.gradient(phi[1:-1, 1:-1, 1:-1], y, axis=1, edge_order=2)
+    return out
+
+
+def d_dz(phi: np.ndarray, dz: np.ndarray) -> np.ndarray:
+    out = np.zeros_like(phi)
+    z = _cell_centers_from_widths(dz)
+    out[1:-1, 1:-1, 1:-1] = np.gradient(phi[1:-1, 1:-1, 1:-1], z, axis=2, edge_order=2)
+    return out
+
+
+def gradient(phi: np.ndarray, mesh: StructuredMesh) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    return d_dx(phi, mesh.dx), d_dy(phi, mesh.dy), d_dz(phi, mesh.dz)
+
+
+def divergence(u: np.ndarray, v: np.ndarray, w: np.ndarray, mesh: StructuredMesh) -> np.ndarray:
+    return d_dx(u, mesh.dx) + d_dy(v, mesh.dy) + d_dz(w, mesh.dz)
+
+
+def laplacian(phi: np.ndarray, mesh: StructuredMesh) -> np.ndarray:
+    out = np.zeros_like(phi)
+    x = _cell_centers_from_widths(mesh.dx)
+    y = _cell_centers_from_widths(mesh.dy)
+    z = _cell_centers_from_widths(mesh.dz)
+    core = phi[1:-1, 1:-1, 1:-1]
+    d2x = np.gradient(np.gradient(core, x, axis=0, edge_order=2), x, axis=0, edge_order=2)
+    d2y = np.gradient(np.gradient(core, y, axis=1, edge_order=2), y, axis=1, edge_order=2)
+    d2z = np.gradient(np.gradient(core, z, axis=2, edge_order=2), z, axis=2, edge_order=2)
+    out[1:-1, 1:-1, 1:-1] = d2x + d2y + d2z
+    return out
+
+
+def strain_rate(u: np.ndarray, v: np.ndarray, w: np.ndarray, mesh: StructuredMesh) -> tuple[np.ndarray, np.ndarray]:
+    dudx, dudy, dudz = gradient(u, mesh)
+    dvdx, dvdy, dvdz = gradient(v, mesh)
+    dwdx, dwdy, dwdz = gradient(w, mesh)
+    s2 = (
+        dudx**2 + dvdy**2 + dwdz**2
+        + 2.0 * (0.5 * (dudy + dvdx)) ** 2
+        + 2.0 * (0.5 * (dudz + dwdx)) ** 2
+        + 2.0 * (0.5 * (dvdz + dwdy)) ** 2
+    )
+    mag_s = np.sqrt(2.0 * s2)
+    return mag_s, s2
+
+
+def vorticity_magnitude(u: np.ndarray, v: np.ndarray, w: np.ndarray, mesh: StructuredMesh) -> np.ndarray:
+    _, dudy, dudz = gradient(u, mesh)
+    dvdx, _, dvdz = gradient(v, mesh)
+    dwdx, dwdy, _ = gradient(w, mesh)
+    wx = dwdy - dvdz
+    wy = dudz - dwdx
+    wz = dvdx - dudy
+    return np.sqrt(wx**2 + wy**2 + wz**2)

--- a/cfdles/pressure.py
+++ b/cfdles/pressure.py
@@ -1,0 +1,99 @@
+"""Pressure Poisson solvers (CG and BiCGSTAB) with Jacobi preconditioning."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .bc import apply_pressure_bcs
+from .config import SolverConfig
+from .mesh import StructuredMesh
+from .operators import laplacian
+
+
+def _apply_a(phi: np.ndarray, mesh: StructuredMesh, cfg: SolverConfig) -> np.ndarray:
+    out = laplacian(phi, mesh)
+    out[1:-1, 1:-1, 1:-1] *= (1.0 - mesh.mask_solid)
+    apply_pressure_bcs(out, cfg)
+    return out
+
+
+def _diag(mesh: StructuredMesh) -> np.ndarray:
+    dx2 = mesh.dx[:, None, None] ** 2
+    dy2 = mesh.dy[None, :, None] ** 2
+    dz2 = mesh.dz[None, None, :] ** 2
+    return -2.0 * (1.0 / dx2 + 1.0 / dy2 + 1.0 / dz2)
+
+
+def solve_pressure(p: np.ndarray, rhs: np.ndarray, mesh: StructuredMesh, cfg: SolverConfig) -> tuple[np.ndarray, float, int]:
+    b = np.zeros_like(p)
+    b[1:-1, 1:-1, 1:-1] = rhs
+    if set(cfg.bcs.get("periodic", [])) >= {"x", "z"}:
+        b[1:-1, 1:-1, 1:-1] -= np.mean(rhs)
+
+    if cfg.pressure_solver == "bicgstab":
+        return _bicgstab(p, b, mesh, cfg)
+    return _cg(p, b, mesh, cfg)
+
+
+def _cg(p: np.ndarray, b: np.ndarray, mesh: StructuredMesh, cfg: SolverConfig) -> tuple[np.ndarray, float, int]:
+    d = _diag(mesh)
+    x = p.copy()
+    apply_pressure_bcs(x, cfg)
+    r = b - _apply_a(x, mesh, cfg)
+    z = np.zeros_like(x)
+    z[1:-1, 1:-1, 1:-1] = r[1:-1, 1:-1, 1:-1] / np.where(np.abs(d) > 1e-12, d, -1.0)
+    pvec = z.copy()
+    rz_old = np.sum(r[1:-1, 1:-1, 1:-1] * z[1:-1, 1:-1, 1:-1])
+    bnorm = np.linalg.norm(b[1:-1, 1:-1, 1:-1]) + 1e-30
+    res = 1.0
+    for it in range(1, cfg.pressure_max_iter + 1):
+        ap = _apply_a(pvec, mesh, cfg)
+        alpha = rz_old / (np.sum(pvec[1:-1, 1:-1, 1:-1] * ap[1:-1, 1:-1, 1:-1]) + 1e-30)
+        x[1:-1, 1:-1, 1:-1] += alpha * pvec[1:-1, 1:-1, 1:-1]
+        r[1:-1, 1:-1, 1:-1] -= alpha * ap[1:-1, 1:-1, 1:-1]
+        apply_pressure_bcs(x, cfg)
+        res = np.linalg.norm(r[1:-1, 1:-1, 1:-1]) / bnorm
+        if res < cfg.pressure_tol:
+            return x, res, it
+        z[1:-1, 1:-1, 1:-1] = r[1:-1, 1:-1, 1:-1] / np.where(np.abs(d) > 1e-12, d, -1.0)
+        rz_new = np.sum(r[1:-1, 1:-1, 1:-1] * z[1:-1, 1:-1, 1:-1])
+        beta = rz_new / (rz_old + 1e-30)
+        pvec[1:-1, 1:-1, 1:-1] = z[1:-1, 1:-1, 1:-1] + beta * pvec[1:-1, 1:-1, 1:-1]
+        rz_old = rz_new
+    return x, res, cfg.pressure_max_iter
+
+
+def _bicgstab(p: np.ndarray, b: np.ndarray, mesh: StructuredMesh, cfg: SolverConfig) -> tuple[np.ndarray, float, int]:
+    d = _diag(mesh)
+    x = p.copy()
+    apply_pressure_bcs(x, cfg)
+    r = b - _apply_a(x, mesh, cfg)
+    r0 = r.copy()
+    v = np.zeros_like(r)
+    pvec = np.zeros_like(r)
+    alpha = omega = rho_old = 1.0
+    bnorm = np.linalg.norm(b[1:-1, 1:-1, 1:-1]) + 1e-30
+    res = 1.0
+    for it in range(1, cfg.pressure_max_iter + 1):
+        rho = np.sum(r0[1:-1, 1:-1, 1:-1] * r[1:-1, 1:-1, 1:-1])
+        beta = (rho / (rho_old + 1e-30)) * (alpha / (omega + 1e-30))
+        pvec[1:-1, 1:-1, 1:-1] = r[1:-1, 1:-1, 1:-1] + beta * (pvec[1:-1, 1:-1, 1:-1] - omega * v[1:-1, 1:-1, 1:-1])
+        phat = np.zeros_like(r)
+        phat[1:-1, 1:-1, 1:-1] = pvec[1:-1, 1:-1, 1:-1] / np.where(np.abs(d) > 1e-12, d, -1.0)
+        v = _apply_a(phat, mesh, cfg)
+        alpha = rho / (np.sum(r0[1:-1, 1:-1, 1:-1] * v[1:-1, 1:-1, 1:-1]) + 1e-30)
+        s = r.copy()
+        s[1:-1, 1:-1, 1:-1] -= alpha * v[1:-1, 1:-1, 1:-1]
+        shat = np.zeros_like(r)
+        shat[1:-1, 1:-1, 1:-1] = s[1:-1, 1:-1, 1:-1] / np.where(np.abs(d) > 1e-12, d, -1.0)
+        t = _apply_a(shat, mesh, cfg)
+        omega = np.sum(t[1:-1, 1:-1, 1:-1] * s[1:-1, 1:-1, 1:-1]) / (np.sum(t[1:-1, 1:-1, 1:-1] ** 2) + 1e-30)
+        x[1:-1, 1:-1, 1:-1] += alpha * phat[1:-1, 1:-1, 1:-1] + omega * shat[1:-1, 1:-1, 1:-1]
+        r = s.copy()
+        r[1:-1, 1:-1, 1:-1] -= omega * t[1:-1, 1:-1, 1:-1]
+        apply_pressure_bcs(x, cfg)
+        res = np.linalg.norm(r[1:-1, 1:-1, 1:-1]) / bnorm
+        if res < cfg.pressure_tol:
+            return x, res, it
+        rho_old = rho
+    return x, res, cfg.pressure_max_iter

--- a/cfdles/sgs.py
+++ b/cfdles/sgs.py
@@ -1,0 +1,40 @@
+"""Subgrid scale models."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .config import SolverConfig
+from .mesh import StructuredMesh
+from .operators import strain_rate
+
+
+def _wall_distance(mesh: StructuredMesh, cfg: SolverConfig) -> np.ndarray:
+    y = mesh.yc
+    ly = cfg.mesh.lengths[1]
+    d = np.minimum(y, ly - y)
+    return np.maximum(d[None, :, None], 1e-8)
+
+
+def smagorinsky_lilly(
+    u: np.ndarray,
+    v: np.ndarray,
+    w: np.ndarray,
+    mesh: StructuredMesh,
+    cfg: SolverConfig,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return (nu_t, |S|) using Smagorinsky-Lilly and optional Van Driest damping."""
+    mag_s, _ = strain_rate(u, v, w, mesh)
+    cs = cfg.les.cs
+    nu_t = (cs * mesh.delta) ** 2 * mag_s[1:-1, 1:-1, 1:-1]
+
+    if cfg.les.wall_damping:
+        d = _wall_distance(mesh, cfg)
+        nu = cfg.nu
+        u_tau = max(np.sqrt(nu * np.max(np.abs(u[1:-1, 1:-1, 1:-1])) / max(cfg.mesh.lengths[1], 1e-8)), 1e-6)
+        y_plus = d * u_tau / nu
+        damp = (1.0 - np.exp(-y_plus / cfg.les.van_driest_a_plus)) ** 2
+        nu_t *= damp
+
+    nu_t *= (1.0 - mesh.mask_solid)
+    return nu_t, mag_s[1:-1, 1:-1, 1:-1]

--- a/cfdles/timestepper.py
+++ b/cfdles/timestepper.py
@@ -9,6 +9,7 @@ from .bc import apply_pressure_bcs, apply_velocity_bcs
 from .config import SolverConfig
 from .diagnostics import append_log, compute_diagnostics
 from .io_vtk import write_vtk_rectilinear
+from .io_npz import write_snapshot_npz
 from .mesh import StructuredMesh, generate_mesh
 from .operators import divergence, gradient, laplacian
 from .pressure import solve_pressure
@@ -132,6 +133,19 @@ def run_simulation(cfg: SolverConfig) -> None:
                     "S_mag": mag_s,
                     "divergence": div,
                 },
+            )
+            write_snapshot_npz(
+                out_dir / f"{cfg.output.prefix}_{step:05d}.npz",
+                mesh,
+                u[1:-1, 1:-1, 1:-1],
+                v[1:-1, 1:-1, 1:-1],
+                w[1:-1, 1:-1, 1:-1],
+                p[1:-1, 1:-1, 1:-1],
+                nu_t,
+                mag_s,
+                div,
+                t,
+                step,
             )
 
         if t >= cfg.time.t_end or dt <= 1e-12:

--- a/cfdles/timestepper.py
+++ b/cfdles/timestepper.py
@@ -1,0 +1,138 @@
+"""Projection timestepper for incompressible LES."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import numpy as np
+
+from .bc import apply_pressure_bcs, apply_velocity_bcs
+from .config import SolverConfig
+from .diagnostics import append_log, compute_diagnostics
+from .io_vtk import write_vtk_rectilinear
+from .mesh import StructuredMesh, generate_mesh
+from .operators import divergence, gradient, laplacian
+from .pressure import solve_pressure
+from .sgs import smagorinsky_lilly
+
+
+def _alloc_field(mesh: StructuredMesh) -> np.ndarray:
+    return np.zeros((mesh.nx + 2, mesh.ny + 2, mesh.nz + 2), dtype=float)
+
+
+def _advective_term(phi: np.ndarray, u: np.ndarray, v: np.ndarray, w: np.ndarray, mesh: StructuredMesh, scheme: str, blend: float) -> np.ndarray:
+    gx, gy, gz = gradient(phi, mesh)
+    central = u * gx + v * gy + w * gz
+    if scheme == "upwind":
+        out = np.zeros_like(phi)
+        dx = mesh.dx[:, None, None]
+        dy = mesh.dy[None, :, None]
+        dz = mesh.dz[None, None, :]
+        dxb = (phi[1:-1, 1:-1, 1:-1] - phi[:-2, 1:-1, 1:-1]) / dx
+        dxf = (phi[2:, 1:-1, 1:-1] - phi[1:-1, 1:-1, 1:-1]) / dx
+        dyb = (phi[1:-1, 1:-1, 1:-1] - phi[1:-1, :-2, 1:-1]) / dy
+        dyf = (phi[1:-1, 2:, 1:-1] - phi[1:-1, 1:-1, 1:-1]) / dy
+        dzb = (phi[1:-1, 1:-1, 1:-1] - phi[1:-1, 1:-1, :-2]) / dz
+        dzf = (phi[1:-1, 1:-1, 2:] - phi[1:-1, 1:-1, 1:-1]) / dz
+        out[1:-1, 1:-1, 1:-1] = (
+            np.where(u[1:-1, 1:-1, 1:-1] >= 0.0, u[1:-1, 1:-1, 1:-1] * dxb, u[1:-1, 1:-1, 1:-1] * dxf)
+            + np.where(v[1:-1, 1:-1, 1:-1] >= 0.0, v[1:-1, 1:-1, 1:-1] * dyb, v[1:-1, 1:-1, 1:-1] * dyf)
+            + np.where(w[1:-1, 1:-1, 1:-1] >= 0.0, w[1:-1, 1:-1, 1:-1] * dzb, w[1:-1, 1:-1, 1:-1] * dzf)
+        )
+        return out
+    return (1.0 - blend) * central + blend * 0.5 * np.sign(central) * np.abs(central)
+
+
+def _effective_laplacian(phi: np.ndarray, nu_eff: np.ndarray, mesh: StructuredMesh) -> np.ndarray:
+    return nu_eff * laplacian(phi, mesh)
+
+
+def _compute_dt(cfg: SolverConfig, mesh: StructuredMesh, u: np.ndarray, v: np.ndarray, w: np.ndarray, nu_eff_max: float) -> float:
+    if cfg.time.dt is not None:
+        return cfg.time.dt
+    ui, vi, wi = u[1:-1, 1:-1, 1:-1], v[1:-1, 1:-1, 1:-1], w[1:-1, 1:-1, 1:-1]
+    speed_max = np.max(np.sqrt(ui**2 + vi**2 + wi**2)) + 1e-8
+    hmin = min(np.min(mesh.dx), np.min(mesh.dy), np.min(mesh.dz))
+    dt_cfl = cfg.time.cfl_target * hmin / speed_max
+    dt_diff = 0.25 * hmin**2 / max(nu_eff_max, 1e-10)
+    return float(min(dt_cfl, dt_diff))
+
+
+def _add_brinkman_penalization(rhs: np.ndarray, phi: np.ndarray, mesh: StructuredMesh, cfg: SolverConfig) -> None:
+    if cfg.domain != "sphere":
+        return
+    eta = float(cfg.sphere.get("eta", 5e-4))
+    rhs[1:-1, 1:-1, 1:-1] += -(mesh.mask_solid / eta) * phi[1:-1, 1:-1, 1:-1]
+
+
+def run_simulation(cfg: SolverConfig) -> None:
+    """Run full LES simulation from config."""
+    mesh = generate_mesh(cfg)
+    out_dir = Path(cfg.output.directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    log_path = out_dir / f"{cfg.output.prefix}_log.csv"
+
+    u, v, w, p = (_alloc_field(mesh) for _ in range(4))
+    apply_velocity_bcs(u, v, w, cfg)
+    apply_pressure_bcs(p, cfg)
+
+    t = 0.0
+    for step in range(1, cfg.time.max_steps + 1):
+        nu_t, mag_s = smagorinsky_lilly(u, v, w, mesh, cfg)
+        nu_eff = cfg.nu + nu_t
+        dt = _compute_dt(cfg, mesh, u, v, w, float(np.max(nu_eff)))
+        if t + dt > cfg.time.t_end:
+            dt = cfg.time.t_end - t
+
+        adv_u = _advective_term(u, u, v, w, mesh, cfg.convection_scheme, cfg.central_blend)
+        adv_v = _advective_term(v, u, v, w, mesh, cfg.convection_scheme, cfg.central_blend)
+        adv_w = _advective_term(w, u, v, w, mesh, cfg.convection_scheme, cfg.central_blend)
+
+        u_star, v_star, w_star = u.copy(), v.copy(), w.copy()
+        lap_u = _effective_laplacian(u, cfg.nu + nu_t.mean(), mesh)
+        lap_v = _effective_laplacian(v, cfg.nu + nu_t.mean(), mesh)
+        lap_w = _effective_laplacian(w, cfg.nu + nu_t.mean(), mesh)
+
+        fx, fy, fz = cfg.body_force
+        u_star[1:-1, 1:-1, 1:-1] += dt * (-adv_u[1:-1, 1:-1, 1:-1] + lap_u[1:-1, 1:-1, 1:-1] + fx)
+        v_star[1:-1, 1:-1, 1:-1] += dt * (-adv_v[1:-1, 1:-1, 1:-1] + lap_v[1:-1, 1:-1, 1:-1] + fy)
+        w_star[1:-1, 1:-1, 1:-1] += dt * (-adv_w[1:-1, 1:-1, 1:-1] + lap_w[1:-1, 1:-1, 1:-1] + fz)
+
+        _add_brinkman_penalization(u_star, u, mesh, cfg)
+        _add_brinkman_penalization(v_star, v, mesh, cfg)
+        _add_brinkman_penalization(w_star, w, mesh, cfg)
+
+        apply_velocity_bcs(u_star, v_star, w_star, cfg)
+
+        div_star = divergence(u_star, v_star, w_star, mesh)[1:-1, 1:-1, 1:-1]
+        rhs = (cfg.rho / max(dt, 1e-12)) * div_star
+        p, pres_res, _ = solve_pressure(p, rhs, mesh, cfg)
+        dpx, dpy, dpz = gradient(p, mesh)
+
+        u[1:-1, 1:-1, 1:-1] = u_star[1:-1, 1:-1, 1:-1] - dt / cfg.rho * dpx[1:-1, 1:-1, 1:-1]
+        v[1:-1, 1:-1, 1:-1] = v_star[1:-1, 1:-1, 1:-1] - dt / cfg.rho * dpy[1:-1, 1:-1, 1:-1]
+        w[1:-1, 1:-1, 1:-1] = w_star[1:-1, 1:-1, 1:-1] - dt / cfg.rho * dpz[1:-1, 1:-1, 1:-1]
+        apply_velocity_bcs(u, v, w, cfg)
+        apply_pressure_bcs(p, cfg)
+
+        t += dt
+        diag = compute_diagnostics(u, v, w, nu_t, mesh, dt, pres_res)
+        append_log(log_path, step, t, dt, diag)
+
+        if step % cfg.output.interval == 0 or t >= cfg.time.t_end or step == 1:
+            div = divergence(u, v, w, mesh)[1:-1, 1:-1, 1:-1]
+            write_vtk_rectilinear(
+                out_dir / f"{cfg.output.prefix}_{step:05d}.vtk",
+                mesh,
+                {
+                    "u": u[1:-1, 1:-1, 1:-1],
+                    "v": v[1:-1, 1:-1, 1:-1],
+                    "w": w[1:-1, 1:-1, 1:-1],
+                    "p": p[1:-1, 1:-1, 1:-1],
+                    "nu_t": nu_t,
+                    "S_mag": mag_s,
+                    "divergence": div,
+                },
+            )
+
+        if t >= cfg.time.t_end or dt <= 1e-12:
+            break

--- a/demos/cavity.json
+++ b/demos/cavity.json
@@ -1,0 +1,49 @@
+{
+  "domain": "cavity",
+  "rho": 1.0,
+  "nu": 0.01,
+  "body_force": [0.0, 0.0, 0.0],
+  "mesh": {
+    "nx": 24,
+    "ny": 24,
+    "nz": 24,
+    "lengths": [1.0, 1.0, 1.0],
+    "near_wall_stretching": {
+      "axis": "y",
+      "type": "tanh",
+      "strength": 1.4
+    },
+    "refinement_zones": [
+      {
+        "min": [0.3, 0.3, 0.3],
+        "max": [0.7, 0.7, 0.7],
+        "factor": 1.7
+      }
+    ]
+  },
+  "time": {
+    "cfl_target": 0.4,
+    "t_end": 1.0,
+    "max_steps": 400
+  },
+  "les": {
+    "cs": 0.17,
+    "wall_damping": true,
+    "van_driest_a_plus": 26.0
+  },
+  "convection_scheme": "upwind",
+  "output": {
+    "interval": 20,
+    "directory": "outputs/cavity",
+    "prefix": "cavity"
+  },
+  "pressure_solver": "cg",
+  "pressure_tol": 1e-6,
+  "pressure_max_iter": 250,
+  "bcs": {
+    "moving_wall": {
+      "u": 1.0
+    },
+    "periodic": []
+  }
+}

--- a/demos/channel.json
+++ b/demos/channel.json
@@ -1,0 +1,44 @@
+{
+  "domain": "channel",
+  "rho": 1.0,
+  "nu": 0.004,
+  "body_force": [0.02, 0.0, 0.0],
+  "mesh": {
+    "nx": 32,
+    "ny": 24,
+    "nz": 24,
+    "lengths": [2.0, 1.0, 1.0],
+    "near_wall_stretching": {
+      "axis": "y",
+      "type": "tanh",
+      "strength": 2.2
+    },
+    "refinement_zones": []
+  },
+  "time": {
+    "cfl_target": 0.5,
+    "t_end": 1.2,
+    "max_steps": 500
+  },
+  "les": {
+    "cs": 0.17,
+    "wall_damping": true,
+    "van_driest_a_plus": 26.0
+  },
+  "convection_scheme": "central",
+  "central_blend": 0.12,
+  "output": {
+    "interval": 25,
+    "directory": "outputs/channel",
+    "prefix": "channel"
+  },
+  "pressure_solver": "bicgstab",
+  "pressure_tol": 1e-6,
+  "pressure_max_iter": 300,
+  "bcs": {
+    "periodic": ["x", "z"],
+    "moving_wall": {
+      "u": 0.0
+    }
+  }
+}

--- a/demos/sphere.json
+++ b/demos/sphere.json
@@ -1,0 +1,45 @@
+{
+  "domain": "sphere",
+  "rho": 1.0,
+  "nu": 0.005,
+  "body_force": [0.01, 0.0, 0.0],
+  "mesh": {
+    "nx": 36,
+    "ny": 24,
+    "nz": 24,
+    "lengths": [2.5, 1.0, 1.0],
+    "refinement_zones": [
+      {
+        "min": [0.8, 0.2, 0.2],
+        "max": [1.4, 0.8, 0.8],
+        "factor": 2.2
+      }
+    ]
+  },
+  "sphere": {
+    "center": [1.1, 0.5, 0.5],
+    "radius": 0.18,
+    "eta": 0.001
+  },
+  "time": {
+    "cfl_target": 0.4,
+    "t_end": 0.6,
+    "max_steps": 300
+  },
+  "les": {
+    "cs": 0.17,
+    "wall_damping": false
+  },
+  "convection_scheme": "upwind",
+  "output": {
+    "interval": 20,
+    "directory": "outputs/sphere",
+    "prefix": "sphere"
+  },
+  "pressure_solver": "bicgstab",
+  "bcs": {
+    "periodic": ["z"],
+    "inflow": {"at": "zmin", "velocity": [0.5, 0.0, 0.0]},
+    "outflow": {"at": "zmax"}
+  }
+}

--- a/plot_results.py
+++ b/plot_results.py
@@ -1,0 +1,51 @@
+"""Simple plotting helpers for logged diagnostics and velocity slices."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import numpy as np
+import matplotlib.pyplot as plt
+
+from cfdles.mesh import generate_mesh
+from cfdles.config import load_config
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("config", help="Config used in simulation")
+    args = parser.parse_args()
+
+    cfg = load_config(args.config)
+    log = Path(cfg.output.directory) / f"{cfg.output.prefix}_log.csv"
+    data = np.genfromtxt(log, delimiter=",", names=True)
+
+    fig, axs = plt.subplots(1, 2, figsize=(10, 4))
+    axs[0].plot(data["time"], data["kinetic_energy"])
+    axs[0].set_title("Kinetic energy vs time")
+    axs[0].set_xlabel("time")
+    axs[0].set_ylabel("KE")
+
+    axs[1].plot(data["time"], data["div_l2"])
+    axs[1].set_title("Divergence L2 vs time")
+    axs[1].set_xlabel("time")
+    axs[1].set_ylabel("||div||")
+
+    plt.tight_layout()
+    out = Path(cfg.output.directory) / f"{cfg.output.prefix}_diagnostics.png"
+    plt.savefig(out, dpi=140)
+
+    mesh = generate_mesh(cfg)
+    yc = mesh.yc
+    centerline = 0.5 * (1.0 - np.abs(2.0 * yc / cfg.mesh.lengths[1] - 1.0))
+    plt.figure(figsize=(4, 4))
+    plt.plot(centerline, yc)
+    plt.xlabel("u (qualitative profile)")
+    plt.ylabel("y")
+    plt.title("Centerline velocity template")
+    plt.tight_layout()
+    plt.savefig(Path(cfg.output.directory) / f"{cfg.output.prefix}_centerline_template.png", dpi=140)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "cfdles"
+version = "0.1.0"
+description = "Educational 3D incompressible LES CFD solver in Python"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+  "numpy>=1.24",
+  "matplotlib>=3.7",
+  "pytest>=7.0"
+]
+
+[tool.setuptools]
+packages = ["cfdles"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+numpy>=1.24
+matplotlib>=3.7
+pytest>=7.0

--- a/run_demo.py
+++ b/run_demo.py
@@ -1,0 +1,21 @@
+"""Run configured LES demo case."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from cfdles.config import load_config
+from cfdles.timestepper import run_simulation
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run CFD LES demo")
+    parser.add_argument("config", nargs="?", default="demos/cavity.json", help="Path to JSON config")
+    args = parser.parse_args()
+    cfg = load_config(Path(args.config))
+    run_simulation(cfg)
+
+
+if __name__ == "__main__":
+    main()

--- a/run_gui.py
+++ b/run_gui.py
@@ -1,0 +1,7 @@
+"""Launch desktop GUI for CFDLES."""
+
+from cfdles.gui import main
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import numpy as np
+
+from cfdles.config import SolverConfig
+from cfdles.mesh import generate_mesh
+from cfdles.operators import d_dx, divergence
+
+
+def test_grad_sin_matches_cos() -> None:
+    cfg = SolverConfig()
+    cfg.mesh.nx = 32
+    cfg.mesh.ny = 8
+    cfg.mesh.nz = 8
+    cfg.mesh.lengths = (2.0 * np.pi, 1.0, 1.0)
+    cfg.bcs = {"periodic": ["x"]}
+    mesh = generate_mesh(cfg)
+
+    phi = np.zeros((mesh.nx + 2, mesh.ny + 2, mesh.nz + 2))
+    X = mesh.xc[:, None, None]
+    phi[1:-1, 1:-1, 1:-1] = np.sin(X)
+    phi[0, 1:-1, 1:-1] = phi[-2, 1:-1, 1:-1]
+    phi[-1, 1:-1, 1:-1] = phi[1, 1:-1, 1:-1]
+    phi[:, 0, :] = phi[:, 1, :]
+    phi[:, -1, :] = phi[:, -2, :]
+    phi[:, :, 0] = phi[:, :, 1]
+    phi[:, :, -1] = phi[:, :, -2]
+
+    num = d_dx(phi, mesh.dx)[1:-1, 1:-1, 1:-1]
+    exact = np.cos(X)
+    err = np.sqrt(np.mean((num[:, 0, 0] - exact[:, 0, 0]) ** 2))
+    assert err < 0.12
+
+
+def test_divergence_free_field_is_small() -> None:
+    cfg = SolverConfig()
+    cfg.mesh.nx = 16
+    cfg.mesh.ny = 16
+    cfg.mesh.nz = 16
+    cfg.mesh.lengths = (1.0, 1.0, 1.0)
+    cfg.bcs = {"periodic": ["x", "y", "z"]}
+    mesh = generate_mesh(cfg)
+
+    u = np.zeros((mesh.nx + 2, mesh.ny + 2, mesh.nz + 2))
+    v = np.zeros_like(u)
+    w = np.zeros_like(u)
+
+    X, Y, Z = np.meshgrid(mesh.xc, mesh.yc, mesh.zc, indexing="ij")
+    u[1:-1, 1:-1, 1:-1] = np.sin(2 * np.pi * Y)
+    v[1:-1, 1:-1, 1:-1] = np.sin(2 * np.pi * Z)
+    w[1:-1, 1:-1, 1:-1] = np.sin(2 * np.pi * X)
+
+    for arr in (u, v, w):
+        arr[0, :, :] = arr[-2, :, :]
+        arr[-1, :, :] = arr[1, :, :]
+        arr[:, 0, :] = arr[:, -2, :]
+        arr[:, -1, :] = arr[:, 1, :]
+        arr[:, :, 0] = arr[:, :, -2]
+        arr[:, :, -1] = arr[:, :, 1]
+
+    div = divergence(u, v, w, mesh)[1:-1, 1:-1, 1:-1]
+    assert np.sqrt(np.mean(div**2)) < 0.35


### PR DESCRIPTION
### Motivation
- Provide a self-contained, easy-to-run educational 3D incompressible Navier–Stokes LES solver in Python with minimal setup for experimentation and extension.
- Deliver a structured finite-volume-like implementation (hexahedral cells, ghost cells) with LES SGS, projection pressure solve, and automatic mesh generation for typical demo domains.
- Make core components modular and configurable so users can switch SGS models, convection schemes, boundary conditions, and solver options via JSON.

### Description
- Added a new `cfdles` package implementing mesh generation (`mesh.py`), discrete operators (`operators.py`), BCs (`bc.py`), SGS models (`sgs.py`), pressure solvers (`pressure.py`), timestepper/projection method (`timestepper.py`), VTK output (`io_vtk.py`), diagnostics (`diagnostics.py`) and configuration (`config.py`).
- Implemented Smagorinsky–Lilly SGS with optional Van Driest wall damping and Brinkman penalization for immersed-sphere cases, plus selectable convection (`central`/`upwind`) and explicit diffusion with CFL+diffusion dt control.
- Implemented matrix-free Poisson solvers: CG (default) and BiCGSTAB fallback with Jacobi preconditioning and pressure-reference anchoring for periodic cases.
- Added demos and utilities: `demos/{cavity.json,channel.json,sphere.json}`, `run_demo.py` entrypoint, `plot_results.py` diagnostics plotting, VTK output of `u,v,w,p,nu_t,S_mag,divergence`, and a small test suite `tests/test_operators.py` for gradient/divergence checks.

### Testing
- Installed the package in editable mode with `python -m pip install -e .` which completed successfully.
- Ran unit tests with `pytest -q` and the operator tests passed (`2 passed`).
- Executed a smoke demo with `python run_demo.py demos/cavity.json` which completed and produced VTK and CSV outputs (e.g. `outputs/cavity/*.vtk`, `outputs/cavity/cavity_log.csv`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994531fea8883258bcfba1be09a7376)