### PR TITLE
Add modular Monopoly-style game platform (engine, UI, editor) with built-in default game

### DIFF
--- a/data/defaultMonopoly.js
+++ b/data/defaultMonopoly.js
@@ -1,0 +1,85 @@
+export const defaultMonopoly = {
+  meta: {
+    name: 'Classic Monopoly',
+    version: '1.0.0'
+  },
+  rules: {
+    startingMoney: 1500,
+    passGoAmount: 200,
+    jailIndex: 10,
+    goToJailIndex: 30,
+    maxHouses: 4,
+    houseRentMultiplier: 0.9,
+    hotelRentMultiplier: 1.8
+  },
+  decks: [
+    {
+      id: 'chance',
+      name: 'Chance',
+      cards: [
+        { id: 'ch1', description: 'Advance to GO. Collect $200.', actions: [{ type: 'moveTo', square: 0 }, { type: 'receiveMoney', amount: 200 }] },
+        { id: 'ch2', description: 'Bank pays you dividend of $50.', actions: [{ type: 'receiveMoney', amount: 50 }] },
+        { id: 'ch3', description: 'Go to Jail. Do not pass GO.', actions: [{ type: 'goToJail' }] },
+        { id: 'ch4', description: 'Pay poor tax of $15.', actions: [{ type: 'payMoney', amount: 15 }] },
+        { id: 'ch5', description: 'Take a trip to Illinois Avenue.', actions: [{ type: 'moveTo', square: 24 }] },
+        { id: 'ch6', description: 'Advance token to nearest Railroad.', actions: [{ type: 'moveToNearest', category: 'railroad' }] }
+      ]
+    },
+    {
+      id: 'community',
+      name: 'Community Chest',
+      cards: [
+        { id: 'cc1', description: 'Advance to GO. Collect $200.', actions: [{ type: 'moveTo', square: 0 }, { type: 'receiveMoney', amount: 200 }] },
+        { id: 'cc2', description: 'Doctor\'s fees. Pay $50.', actions: [{ type: 'payMoney', amount: 50 }] },
+        { id: 'cc3', description: 'From sale of stock you get $50.', actions: [{ type: 'receiveMoney', amount: 50 }] },
+        { id: 'cc4', description: 'Go to Jail. Do not pass GO.', actions: [{ type: 'goToJail' }] },
+        { id: 'cc5', description: 'It is your birthday. Collect $10 from every player.', actions: [{ type: 'receiveFromAllPlayers', amount: 10 }] },
+        { id: 'cc6', description: 'Pay hospital fees of $100.', actions: [{ type: 'payMoney', amount: 100 }] }
+      ]
+    }
+  ],
+  board: {
+    squares: [
+      { id: 0, name: 'GO', type: 'go', actions: [{ type: 'receiveMoney', amount: 200 }] },
+      { id: 1, name: 'Mediterranean Avenue', type: 'property', group: 'brown', price: 60, baseRent: 2, houseCost: 50 },
+      { id: 2, name: 'Community Chest', type: 'draw', deckId: 'community' },
+      { id: 3, name: 'Baltic Avenue', type: 'property', group: 'brown', price: 60, baseRent: 4, houseCost: 50 },
+      { id: 4, name: 'Income Tax', type: 'tax', amount: 200 },
+      { id: 5, name: 'Reading Railroad', type: 'property', category: 'railroad', group: 'railroad', price: 200, baseRent: 25 },
+      { id: 6, name: 'Oriental Avenue', type: 'property', group: 'lightBlue', price: 100, baseRent: 6, houseCost: 50 },
+      { id: 7, name: 'Chance', type: 'draw', deckId: 'chance' },
+      { id: 8, name: 'Vermont Avenue', type: 'property', group: 'lightBlue', price: 100, baseRent: 6, houseCost: 50 },
+      { id: 9, name: 'Connecticut Avenue', type: 'property', group: 'lightBlue', price: 120, baseRent: 8, houseCost: 50 },
+      { id: 10, name: 'Jail / Just Visiting', type: 'jail' },
+      { id: 11, name: 'St. Charles Place', type: 'property', group: 'pink', price: 140, baseRent: 10, houseCost: 100 },
+      { id: 12, name: 'Electric Company', type: 'property', group: 'utility', price: 150, baseRent: 12 },
+      { id: 13, name: 'States Avenue', type: 'property', group: 'pink', price: 140, baseRent: 10, houseCost: 100 },
+      { id: 14, name: 'Virginia Avenue', type: 'property', group: 'pink', price: 160, baseRent: 12, houseCost: 100 },
+      { id: 15, name: 'Pennsylvania Railroad', type: 'property', category: 'railroad', group: 'railroad', price: 200, baseRent: 25 },
+      { id: 16, name: 'St. James Place', type: 'property', group: 'orange', price: 180, baseRent: 14, houseCost: 100 },
+      { id: 17, name: 'Community Chest', type: 'draw', deckId: 'community' },
+      { id: 18, name: 'Tennessee Avenue', type: 'property', group: 'orange', price: 180, baseRent: 14, houseCost: 100 },
+      { id: 19, name: 'New York Avenue', type: 'property', group: 'orange', price: 200, baseRent: 16, houseCost: 100 },
+      { id: 20, name: 'Free Parking', type: 'freeParking' },
+      { id: 21, name: 'Kentucky Avenue', type: 'property', group: 'red', price: 220, baseRent: 18, houseCost: 150 },
+      { id: 22, name: 'Chance', type: 'draw', deckId: 'chance' },
+      { id: 23, name: 'Indiana Avenue', type: 'property', group: 'red', price: 220, baseRent: 18, houseCost: 150 },
+      { id: 24, name: 'Illinois Avenue', type: 'property', group: 'red', price: 240, baseRent: 20, houseCost: 150 },
+      { id: 25, name: 'B. & O. Railroad', type: 'property', category: 'railroad', group: 'railroad', price: 200, baseRent: 25 },
+      { id: 26, name: 'Atlantic Avenue', type: 'property', group: 'yellow', price: 260, baseRent: 22, houseCost: 150 },
+      { id: 27, name: 'Ventnor Avenue', type: 'property', group: 'yellow', price: 260, baseRent: 22, houseCost: 150 },
+      { id: 28, name: 'Water Works', type: 'property', group: 'utility', price: 150, baseRent: 12 },
+      { id: 29, name: 'Marvin Gardens', type: 'property', group: 'yellow', price: 280, baseRent: 24, houseCost: 150 },
+      { id: 30, name: 'Go To Jail', type: 'goToJail', actions: [{ type: 'goToJail' }] },
+      { id: 31, name: 'Pacific Avenue', type: 'property', group: 'green', price: 300, baseRent: 26, houseCost: 200 },
+      { id: 32, name: 'North Carolina Avenue', type: 'property', group: 'green', price: 300, baseRent: 26, houseCost: 200 },
+      { id: 33, name: 'Community Chest', type: 'draw', deckId: 'community' },
+      { id: 34, name: 'Pennsylvania Avenue', type: 'property', group: 'green', price: 320, baseRent: 28, houseCost: 200 },
+      { id: 35, name: 'Short Line', type: 'property', category: 'railroad', group: 'railroad', price: 200, baseRent: 25 },
+      { id: 36, name: 'Chance', type: 'draw', deckId: 'chance' },
+      { id: 37, name: 'Park Place', type: 'property', group: 'darkBlue', price: 350, baseRent: 35, houseCost: 200 },
+      { id: 38, name: 'Luxury Tax', type: 'tax', amount: 100 },
+      { id: 39, name: 'Boardwalk', type: 'property', group: 'darkBlue', price: 400, baseRent: 50, houseCost: 200 }
+    ]
+  }
+};

--- a/index.html
+++ b/index.html
@@ -1,12 +1,13 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>ChatGPT Panel</title>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Monopoly-Style Board Game Platform</title>
+  <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-    <div id="root"></div>
-    <script src="script.js"></script>
+  <div id="root"></div>
+  <script type="module" src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,13 +1,61 @@
-async function sendMessage() {
-    const message = document.getElementById("message").value;
-    if (!message) return;
+import { defaultMonopoly } from './data/defaultMonopoly.js';
+import { GameEngine } from './src/engine.js';
+import { GameUI } from './src/ui.js';
+import { BoardEditor } from './src/editor.js';
 
-    const response = await fetch("https://chatgpt-backend.onrender.com/chat", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ message })
-    });
+const root = document.getElementById('root');
 
-    const data = await response.json();
-    document.getElementById("response").innerText = data.response || "Hata oluştu!";
+const state = {
+  config: defaultMonopoly,
+  engine: null,
+  ui: null,
+  editor: null
+};
+
+function createPlayers() {
+  const defaults = [
+    { name: 'Player 1', token: '🚗', color: '#f94144' },
+    { name: 'Player 2', token: '🎩', color: '#577590' },
+    { name: 'Player 3', token: '🐕', color: '#43aa8b' },
+    { name: 'Player 4', token: '🛳️', color: '#f9c74f' }
+  ];
+  return defaults;
 }
+
+function mountGame(engine) {
+  state.engine = engine;
+  root.innerHTML = '<h1>Monopoly-Style Board Game Platform</h1><div id="game"></div><div id="editor"></div>';
+
+  state.ui = new GameUI(state.engine, {
+    onSave: (serialized) => localStorage.setItem('boardgame-save', serialized),
+    onLoad: () => {
+      const save = localStorage.getItem('boardgame-save');
+      if (save) {
+        state.engine = GameEngine.fromSerialized(save);
+        mountGame(state.engine);
+      }
+    },
+    onDownload: (serialized) => {
+      const blob = new Blob([serialized], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'boardgame-save.json';
+      a.click();
+      URL.revokeObjectURL(url);
+    },
+    onUpload: (serialized) => {
+      state.engine = GameEngine.fromSerialized(serialized);
+      mountGame(state.engine);
+    }
+  });
+  state.ui.mount(document.getElementById('game'));
+
+  state.editor = new BoardEditor((newConfig) => {
+    state.config = newConfig;
+    mountGame(new GameEngine(newConfig, createPlayers()));
+  });
+  state.editor.mount(document.getElementById('editor'), state.config);
+}
+
+mountGame(new GameEngine(state.config, createPlayers()));

--- a/src/editor.js
+++ b/src/editor.js
@@ -1,0 +1,43 @@
+export class BoardEditor {
+  constructor(onApply) {
+    this.onApply = onApply;
+  }
+
+  mount(root, initialConfig) {
+    root.innerHTML = `
+      <h3>Board Game Editor</h3>
+      <p>Create/edit Monopoly-style game JSON data. Action types supported: moveForward, moveBackward, moveTo, drawCard, payMoney, receiveMoney, payAllPlayers, receiveFromAllPlayers, skipTurns, goToJail, exitJail, customEffect.</p>
+      <div class="editor-controls">
+        <button id="newSquareBtn">Add Square</button>
+        <button id="newDeckBtn">Add Deck</button>
+        <button id="applyConfigBtn">Apply JSON to Game</button>
+      </div>
+      <textarea id="configEditor" spellcheck="false"></textarea>
+    `;
+
+    const textarea = root.querySelector('#configEditor');
+    textarea.value = JSON.stringify(initialConfig, null, 2);
+
+    root.querySelector('#newSquareBtn').onclick = () => {
+      const cfg = JSON.parse(textarea.value);
+      const id = cfg.board.squares.length;
+      cfg.board.squares.push({ id, name: `Custom ${id}`, type: 'custom', actions: [{ type: 'customEffect', message: 'Custom action!' }] });
+      textarea.value = JSON.stringify(cfg, null, 2);
+    };
+
+    root.querySelector('#newDeckBtn').onclick = () => {
+      const cfg = JSON.parse(textarea.value);
+      cfg.decks.push({ id: `deck${cfg.decks.length + 1}`, name: 'New Deck', cards: [] });
+      textarea.value = JSON.stringify(cfg, null, 2);
+    };
+
+    root.querySelector('#applyConfigBtn').onclick = () => {
+      try {
+        const parsed = JSON.parse(textarea.value);
+        this.onApply(parsed);
+      } catch (err) {
+        alert(`Invalid JSON: ${err.message}`);
+      }
+    };
+  }
+}

--- a/src/engine.js
+++ b/src/engine.js
@@ -1,0 +1,333 @@
+export class GameEngine {
+  constructor(config, players) {
+    this.config = structuredClone(config);
+    this.players = players.map((p, idx) => ({
+      id: idx,
+      name: p.name,
+      token: p.token,
+      color: p.color,
+      money: config.rules.startingMoney,
+      position: 0,
+      properties: [],
+      inJail: false,
+      jailTurns: 0,
+      bankrupt: false,
+      skippedTurns: 0
+    }));
+
+    this.state = {
+      currentPlayerIndex: 0,
+      dice: [1, 1],
+      phase: 'roll',
+      winner: null,
+      message: 'Game started.',
+      ownership: {},
+      buildings: {},
+      decks: this.#initializeDecks(config.decks),
+      lastCard: null
+    };
+
+    this.actionHandlers = this.#createActionHandlers();
+  }
+
+  #initializeDecks(decks) {
+    const map = {};
+    for (const deck of decks) {
+      map[deck.id] = {
+        id: deck.id,
+        cards: [...deck.cards],
+        discard: []
+      };
+      this.#shuffle(map[deck.id].cards);
+    }
+    return map;
+  }
+
+  #createActionHandlers() {
+    return {
+      moveForward: (ctx, action) => this.movePlayer(ctx.player.id, action.spaces),
+      moveBackward: (ctx, action) => this.movePlayer(ctx.player.id, -action.spaces),
+      moveTo: (ctx, action) => this.movePlayerTo(ctx.player.id, action.square),
+      moveToNearest: (ctx, action) => this.movePlayerToNearest(ctx.player.id, action.category),
+      drawCard: (ctx, action) => this.drawCard(ctx.player.id, action.deckId),
+      payMoney: (ctx, action) => this.adjustMoney(ctx.player.id, -action.amount),
+      receiveMoney: (ctx, action) => this.adjustMoney(ctx.player.id, action.amount),
+      payAllPlayers: (ctx, action) => this.transferToAll(ctx.player.id, -action.amount),
+      receiveFromAllPlayers: (ctx, action) => this.transferToAll(ctx.player.id, action.amount),
+      skipTurns: (ctx, action) => {
+        ctx.player.skippedTurns += action.turns;
+      },
+      goToJail: (ctx) => this.sendToJail(ctx.player.id),
+      exitJail: (ctx) => {
+        ctx.player.inJail = false;
+        ctx.player.jailTurns = 0;
+      },
+      customEffect: (ctx, action) => {
+        this.state.message = action.message ?? `${ctx.player.name} triggered a custom effect.`;
+      }
+    };
+  }
+
+  get currentPlayer() {
+    return this.players[this.state.currentPlayerIndex];
+  }
+
+  getSquare(index) {
+    return this.config.board.squares[index];
+  }
+
+  rollDice() {
+    const p = this.currentPlayer;
+    if (p.bankrupt || this.state.phase !== 'roll') return;
+
+    if (p.skippedTurns > 0) {
+      p.skippedTurns -= 1;
+      this.state.message = `${p.name} skips this turn.`;
+      return this.endTurn();
+    }
+
+    if (p.inJail) {
+      p.jailTurns -= 1;
+      if (p.jailTurns <= 0) {
+        p.inJail = false;
+        this.state.message = `${p.name} exits jail.`;
+      } else {
+        this.state.message = `${p.name} is in jail (${p.jailTurns} turns left).`;
+        return this.endTurn();
+      }
+    }
+
+    const d1 = 1 + Math.floor(Math.random() * 6);
+    const d2 = 1 + Math.floor(Math.random() * 6);
+    this.state.dice = [d1, d2];
+    const steps = d1 + d2;
+
+    this.state.phase = 'resolving';
+    const passedGo = this.movePlayer(p.id, steps);
+    if (passedGo) this.adjustMoney(p.id, this.config.rules.passGoAmount);
+    this.resolveLanding(p.id);
+  }
+
+  movePlayer(playerId, steps) {
+    const player = this.players[playerId];
+    const total = this.config.board.squares.length;
+    const start = player.position;
+    let target = (start + steps) % total;
+    if (target < 0) target += total;
+    const passedGo = steps > 0 && target < start;
+    player.position = target;
+    return passedGo;
+  }
+
+  movePlayerTo(playerId, squareIndex) {
+    const player = this.players[playerId];
+    const passedGo = squareIndex < player.position;
+    player.position = squareIndex;
+    if (passedGo) this.adjustMoney(playerId, this.config.rules.passGoAmount);
+    this.resolveLanding(playerId);
+  }
+
+  movePlayerToNearest(playerId, category) {
+    const player = this.players[playerId];
+    const squares = this.config.board.squares;
+    for (let i = 1; i <= squares.length; i += 1) {
+      const idx = (player.position + i) % squares.length;
+      if (squares[idx].category === category) {
+        this.movePlayerTo(playerId, idx);
+        return;
+      }
+    }
+  }
+
+  resolveLanding(playerId) {
+    const player = this.players[playerId];
+    const square = this.getSquare(player.position);
+    this.state.message = `${player.name} landed on ${square.name}.`;
+
+    if (square.type === 'property') {
+      const ownerId = this.state.ownership[square.id];
+      if (ownerId === undefined) {
+        this.state.phase = 'buy';
+        this.state.message += ` ${square.name} is available for $${square.price}.`;
+        return;
+      }
+      if (ownerId !== playerId) {
+        const rent = this.calculateRent(square.id);
+        this.adjustMoney(playerId, -rent);
+        this.adjustMoney(ownerId, rent);
+        this.state.message += ` Paid $${rent} rent to ${this.players[ownerId].name}.`;
+      }
+    }
+
+    if (square.type === 'tax') {
+      this.adjustMoney(playerId, -square.amount);
+      this.state.message += ` Paid tax $${square.amount}.`;
+    }
+
+    if (square.type === 'draw') {
+      const card = this.drawCard(playerId, square.deckId);
+      this.state.lastCard = card;
+      this.state.message += ` Drew card: ${card.description}`;
+    }
+
+    if (square.actions?.length) {
+      for (const action of square.actions) {
+        this.executeAction(player, action);
+      }
+    }
+
+    this.checkBankruptcy(playerId);
+    this.state.phase = 'end';
+  }
+
+  executeAction(player, action) {
+    const handler = this.actionHandlers[action.type];
+    if (handler) handler({ player }, action);
+  }
+
+  drawCard(playerId, deckId) {
+    const deck = this.state.decks[deckId];
+    if (!deck.cards.length) {
+      deck.cards = [...deck.discard];
+      deck.discard = [];
+      this.#shuffle(deck.cards);
+    }
+    const card = deck.cards.shift();
+    deck.discard.push(card);
+    for (const action of card.actions ?? []) {
+      this.executeAction(this.players[playerId], action);
+    }
+    return card;
+  }
+
+  buyProperty() {
+    const p = this.currentPlayer;
+    const square = this.getSquare(p.position);
+    if (this.state.phase !== 'buy' || square.type !== 'property') return false;
+    if (p.money < square.price) return false;
+    this.adjustMoney(p.id, -square.price);
+    p.properties.push(square.id);
+    this.state.ownership[square.id] = p.id;
+    this.state.message = `${p.name} bought ${square.name} for $${square.price}.`;
+    this.state.phase = 'end';
+    return true;
+  }
+
+  canBuild(playerId, propertyId) {
+    const property = this.getSquare(propertyId);
+    if (!property || property.type !== 'property' || !property.houseCost) return false;
+    const owner = this.state.ownership[propertyId];
+    if (owner !== playerId) return false;
+    const player = this.players[playerId];
+    if (player.money < property.houseCost) return false;
+    const buildings = this.state.buildings[propertyId] ?? { houses: 0, hotel: false };
+    if (buildings.hotel) return false;
+    if (buildings.houses < this.config.rules.maxHouses) return true;
+    return buildings.houses === this.config.rules.maxHouses;
+  }
+
+  buildOnProperty(propertyId) {
+    const p = this.currentPlayer;
+    if (!this.canBuild(p.id, propertyId)) return false;
+    const prop = this.getSquare(propertyId);
+    const buildings = this.state.buildings[propertyId] ?? { houses: 0, hotel: false };
+    if (buildings.houses >= this.config.rules.maxHouses) {
+      buildings.hotel = true;
+    } else {
+      buildings.houses += 1;
+    }
+    this.state.buildings[propertyId] = buildings;
+    this.adjustMoney(p.id, -prop.houseCost);
+    this.state.message = `${p.name} built on ${prop.name}.`;
+    return true;
+  }
+
+  calculateRent(propertyId) {
+    const square = this.getSquare(propertyId);
+    const ownerId = this.state.ownership[propertyId];
+    if (ownerId === undefined) return 0;
+    let rent = square.baseRent;
+
+    if (square.group === 'railroad') {
+      const ownedRailroads = this.players[ownerId].properties.filter((pid) => this.getSquare(pid).group === 'railroad').length;
+      rent = 25 * ownedRailroads;
+    }
+
+    const buildings = this.state.buildings[propertyId] ?? { houses: 0, hotel: false };
+    if (buildings.houses > 0) rent += Math.floor(rent * buildings.houses * this.config.rules.houseRentMultiplier);
+    if (buildings.hotel) rent += Math.floor(rent * this.config.rules.hotelRentMultiplier);
+    return rent;
+  }
+
+  adjustMoney(playerId, amount) {
+    this.players[playerId].money += amount;
+  }
+
+  transferToAll(playerId, amountEach) {
+    const actor = this.players[playerId];
+    for (const p of this.players) {
+      if (p.id === playerId || p.bankrupt) continue;
+      if (amountEach > 0) {
+        this.adjustMoney(p.id, -amountEach);
+        this.adjustMoney(playerId, amountEach);
+      } else {
+        this.adjustMoney(playerId, amountEach);
+        this.adjustMoney(p.id, -amountEach);
+      }
+    }
+    if (actor.money < 0) this.checkBankruptcy(playerId);
+  }
+
+  sendToJail(playerId) {
+    const p = this.players[playerId];
+    p.position = this.config.rules.jailIndex;
+    p.inJail = true;
+    p.jailTurns = 2;
+    this.state.message = `${p.name} goes to jail.`;
+  }
+
+  checkBankruptcy(playerId) {
+    const p = this.players[playerId];
+    if (p.money >= 0 || p.bankrupt) return;
+    p.bankrupt = true;
+    for (const prop of p.properties) {
+      delete this.state.ownership[prop];
+      delete this.state.buildings[prop];
+    }
+    p.properties = [];
+    this.state.message = `${p.name} is bankrupt and out of the game.`;
+    const active = this.players.filter((pl) => !pl.bankrupt);
+    if (active.length === 1) this.state.winner = active[0].id;
+  }
+
+  endTurn() {
+    if (this.state.winner !== null) return;
+    this.state.phase = 'roll';
+    let next = this.state.currentPlayerIndex;
+    for (let i = 0; i < this.players.length; i += 1) {
+      next = (next + 1) % this.players.length;
+      if (!this.players[next].bankrupt) break;
+    }
+    this.state.currentPlayerIndex = next;
+    this.state.lastCard = null;
+  }
+
+  serialize() {
+    return JSON.stringify({ config: this.config, players: this.players, state: this.state });
+  }
+
+  static fromSerialized(serialized) {
+    const parsed = JSON.parse(serialized);
+    const engine = new GameEngine(parsed.config, parsed.players);
+    engine.players = parsed.players;
+    engine.state = parsed.state;
+    return engine;
+  }
+
+  #shuffle(arr) {
+    for (let i = arr.length - 1; i > 0; i -= 1) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [arr[i], arr[j]] = [arr[j], arr[i]];
+    }
+  }
+}

--- a/src/ui.js
+++ b/src/ui.js
@@ -1,0 +1,162 @@
+export class GameUI {
+  constructor(engine, hooks) {
+    this.engine = engine;
+    this.hooks = hooks;
+    this.boardEl = null;
+    this.playersEl = null;
+    this.statusEl = null;
+    this.cardEl = null;
+  }
+
+  mount(root) {
+    root.innerHTML = `
+      <div class="layout">
+        <section>
+          <div id="board" class="board"></div>
+          <div class="controls">
+            <button id="rollBtn">Roll Dice</button>
+            <button id="buyBtn">Buy Property</button>
+            <button id="endTurnBtn">End Turn</button>
+            <button id="saveBtn">Save</button>
+            <button id="loadBtn">Load</button>
+            <button id="downloadBtn">Download Save</button>
+            <label class="upload-label">Upload Save <input id="uploadSave" type="file" accept="application/json" /></label>
+          </div>
+          <div class="status" id="status"></div>
+          <div class="card" id="lastCard"></div>
+        </section>
+        <aside>
+          <h3>Players</h3>
+          <div id="players"></div>
+          <h3>Owned Properties</h3>
+          <div id="properties"></div>
+        </aside>
+      </div>
+    `;
+
+    this.boardEl = root.querySelector('#board');
+    this.playersEl = root.querySelector('#players');
+    this.statusEl = root.querySelector('#status');
+    this.cardEl = root.querySelector('#lastCard');
+
+    root.querySelector('#rollBtn').onclick = () => {
+      this.animateDice();
+      this.engine.rollDice();
+      this.render();
+    };
+    root.querySelector('#buyBtn').onclick = () => {
+      this.engine.buyProperty();
+      this.render();
+    };
+    root.querySelector('#endTurnBtn').onclick = () => {
+      this.engine.endTurn();
+      this.render();
+    };
+
+    root.querySelector('#saveBtn').onclick = () => this.hooks.onSave(this.engine.serialize());
+    root.querySelector('#loadBtn').onclick = () => this.hooks.onLoad();
+    root.querySelector('#downloadBtn').onclick = () => this.hooks.onDownload(this.engine.serialize());
+    root.querySelector('#uploadSave').onchange = (e) => {
+      const file = e.target.files[0];
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = () => this.hooks.onUpload(reader.result);
+      reader.readAsText(file);
+    };
+
+    this.render();
+  }
+
+  render() {
+    this.renderBoard();
+    this.renderPlayers();
+    this.renderProperties();
+
+    const { dice, message, phase, winner, lastCard } = this.engine.state;
+    this.statusEl.textContent = winner !== null
+      ? `${this.engine.players[winner].name} wins!`
+      : `${message} | Dice: ${dice[0]} + ${dice[1]} | Phase: ${phase} | Current: ${this.engine.currentPlayer.name}`;
+
+    this.cardEl.textContent = lastCard ? `Card: ${lastCard.description}` : '';
+  }
+
+  renderBoard() {
+    const squares = this.engine.config.board.squares;
+    this.boardEl.innerHTML = '';
+    for (const square of squares) {
+      const squareEl = document.createElement('div');
+      squareEl.className = `square type-${square.type}`;
+      squareEl.innerHTML = `
+        <strong>${square.name}</strong>
+        <span>${square.type}</span>
+      `;
+
+      const owner = this.engine.state.ownership[square.id];
+      if (owner !== undefined) {
+        squareEl.style.borderColor = this.engine.players[owner].color;
+      }
+
+      const building = this.engine.state.buildings[square.id];
+      if (building) {
+        const label = building.hotel ? '🏨' : `🏠x${building.houses}`;
+        const b = document.createElement('div');
+        b.className = 'building';
+        b.textContent = label;
+        squareEl.appendChild(b);
+      }
+
+      const tokens = document.createElement('div');
+      tokens.className = 'tokens';
+      for (const player of this.engine.players) {
+        if (player.position === square.id && !player.bankrupt) {
+          const token = document.createElement('span');
+          token.className = 'token move-in';
+          token.style.background = player.color;
+          token.textContent = player.token;
+          tokens.appendChild(token);
+        }
+      }
+      squareEl.appendChild(tokens);
+      this.boardEl.appendChild(squareEl);
+    }
+  }
+
+  renderPlayers() {
+    this.playersEl.innerHTML = this.engine.players.map((p, idx) => `
+      <div class="player-card ${idx === this.engine.state.currentPlayerIndex ? 'active' : ''}">
+        <span class="token" style="background:${p.color}">${p.token}</span>
+        <div>
+          <strong>${p.name}</strong>
+          <div>$${p.money} ${p.bankrupt ? '(Bankrupt)' : ''}</div>
+          <div>Position: ${p.position}${p.inJail ? ' | In Jail' : ''}</div>
+        </div>
+      </div>
+    `).join('');
+  }
+
+  renderProperties() {
+    const container = document.querySelector('#properties');
+    const current = this.engine.currentPlayer;
+    const items = current.properties
+      .map((id) => {
+        const sq = this.engine.getSquare(id);
+        const canBuild = this.engine.canBuild(current.id, id);
+        return `<div class="property-item">${sq.name} <button data-build="${id}" ${canBuild ? '' : 'disabled'}>Build</button></div>`;
+      })
+      .join('') || '<p>No properties</p>';
+
+    container.innerHTML = items;
+    container.querySelectorAll('button[data-build]').forEach((btn) => {
+      btn.onclick = () => {
+        this.engine.buildOnProperty(Number(btn.dataset.build));
+        this.render();
+      };
+    });
+  }
+
+  animateDice() {
+    this.statusEl.classList.remove('pulse');
+    void this.statusEl.offsetWidth;
+    this.statusEl.classList.add('pulse');
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,118 @@
-body { text-align: center; font-family: Arial, sans-serif; }
-textarea { width: 50%; height: 100px; }
-button { padding: 10px 20px; margin-top: 10px; }
+:root {
+  --bg: #101522;
+  --panel: #1c2333;
+  --panel-alt: #232c42;
+  --text: #f1f5f9;
+  --muted: #94a3b8;
+  --accent: #3b82f6;
+}
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: Inter, Segoe UI, sans-serif;
+  background: radial-gradient(circle at top, #18223a, var(--bg));
+  color: var(--text);
+}
+
+h1, h3 { margin: 0 0 12px; }
+#root { max-width: 1400px; margin: 0 auto; padding: 16px; }
+
+.layout {
+  display: grid;
+  grid-template-columns: 1fr 320px;
+  gap: 16px;
+}
+
+.board {
+  display: grid;
+  grid-template-columns: repeat(8, minmax(90px, 1fr));
+  gap: 8px;
+}
+.square {
+  min-height: 92px;
+  padding: 8px;
+  border: 2px solid #38445f;
+  border-radius: 10px;
+  background: linear-gradient(180deg, #1e293b, #0f172a);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  transition: transform 0.2s ease;
+}
+.square:hover { transform: translateY(-2px); }
+.square strong { font-size: 0.75rem; }
+.square span { color: var(--muted); font-size: 0.7rem; }
+
+.type-property { border-top: 4px solid #22c55e; }
+.type-tax { border-top: 4px solid #ef4444; }
+.type-draw { border-top: 4px solid #a855f7; }
+.type-jail, .type-goToJail { border-top: 4px solid #f59e0b; }
+.type-go { border-top: 4px solid #3b82f6; }
+
+.tokens { display: flex; gap: 4px; flex-wrap: wrap; }
+.token {
+  width: 26px;
+  height: 26px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+  color: #fff;
+}
+
+.move-in { animation: moveIn .35s ease; }
+@keyframes moveIn { from { transform: scale(.6); opacity: 0; } to { transform: scale(1); opacity: 1; } }
+
+.controls, .status, .card, aside, #editor {
+  margin-top: 10px;
+  padding: 12px;
+  border-radius: 12px;
+  background: var(--panel);
+}
+.controls { display: flex; gap: 8px; flex-wrap: wrap; }
+button, .upload-label {
+  border: none;
+  border-radius: 8px;
+  padding: 9px 12px;
+  background: var(--panel-alt);
+  color: var(--text);
+}
+button:hover { background: var(--accent); cursor: pointer; }
+button:disabled { opacity: 0.4; cursor: not-allowed; }
+.upload-label input { display: none; }
+
+.player-card {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  padding: 8px;
+  margin-bottom: 8px;
+  border-radius: 8px;
+  background: #0f172a;
+}
+.player-card.active { outline: 2px solid var(--accent); }
+
+.property-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 6px;
+}
+
+#editor textarea {
+  width: 100%;
+  min-height: 220px;
+  border-radius: 8px;
+  border: 1px solid #3b4a68;
+  padding: 10px;
+  background: #0f172a;
+  color: var(--text);
+}
+.editor-controls { display: flex; gap: 8px; margin-bottom: 10px; }
+
+.pulse { animation: pulse 0.5s ease; }
+@keyframes pulse { 0% { filter: brightness(1);} 50% { filter: brightness(1.6);} 100% { filter: brightness(1);} }
+
+.building { font-size: 14px; }


### PR DESCRIPTION
### Motivation
- Provide a data-driven, modular board game platform that ships with a fully playable classic Monopoly configuration and a JSON-based editor for creating new Monopoly-style games.
- Separate game logic from rendering so different boards and rule sets can be loaded dynamically and extended with new actions and card effects.
- Deliver a polished desktop-like browser UI with save/load support so users can play immediately and iterate on custom boards.

### Description
- Added a full built-in Monopoly dataset in `data/defaultMonopoly.js` containing rules, 40-square board metadata, Chance/Community decks and cards, and action definitions. 
- Implemented a modular game engine in `src/engine.js` that handles dice/turn flow, movement, landing resolution, property buying/ownership, rent calculation (including houses/hotels and railroads), taxes, jail mechanics, bankruptcy, an extensible action handler map, deck shuffling/drawing, and serialization (`serialize` / `fromSerialized`).
- Implemented the UI layer in `src/ui.js` and a bootstrap `script.js` to mount the app, providing board rendering, token display, ownership/building indicators, controls for roll/buy/end turn, save/load/download/upload hooks, status/card panes, and simple animations/feedback. 
- Added a JSON-based `BoardEditor` in `src/editor.js` that allows adding squares and decks and applying JSON configs at runtime so custom games can be created and loaded without code changes, plus updated `index.html` and `styles.css` for a polished look.

### Testing
- Ran static syntax checks with `node --check script.js`, `node --check src/engine.js`, `node --check src/ui.js`, `node --check src/editor.js`, and `node --check data/defaultMonopoly.js`, all of which succeeded. 
- Launched a local server with `python3 -m http.server 4173` and performed a manual UI validation by loading the app and capturing a Playwright screenshot, which completed successfully. 
- Basic runtime flows exercised during manual UI validation: roll dice, draw cards, buy property, end turn, and save/load operations, all observed to work in the hosted preview.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3eb356b8483259cff0f876ce2379d)